### PR TITLE
feat: knit-rmd-to-pdf has renv-directory parameter now

### DIFF
--- a/knit-rmd-to-pdf/action.yaml
+++ b/knit-rmd-to-pdf/action.yaml
@@ -44,7 +44,7 @@ runs:
     
     - uses: r-lib/actions/setup-pandoc@v2
     - uses: r-lib/actions/setup-tinytex@v2
-            
+    
     - name: Render Rmarkdown files
       shell: bash
       run: |

--- a/knit-rmd-to-pdf/action.yaml
+++ b/knit-rmd-to-pdf/action.yaml
@@ -31,7 +31,7 @@ runs:
         RENV_DIR=${{ inputs.renv-directory }}
         RMD_RELATIVE_PATH="$( realpath --relative-to $RENV_DIR $RMD_PATH )"
 
-        echo "RENV_DIR=\"$RENV_DIR\"" >> $GITHUB_ENV
+        echo "RENV_DIR=$RENV_DIR" >> $GITHUB_ENV
         echo "RMD_RELATIVE_PATH=\"$RMD_RELATIVE_PATH\"" >> $GITHUB_ENV
 
     - uses: r-lib/actions/setup-r@v2

--- a/knit-rmd-to-pdf/action.yaml
+++ b/knit-rmd-to-pdf/action.yaml
@@ -17,23 +17,23 @@ runs:
       shell: bash
       run: |
         # Parent folder, filename, and stem of rmd_path
-        RMD_PATH="${{ inputs.rmd-path }}"
+        RMD_PATH=${{ inputs.rmd-path }}
         RMD_NAME=$( basename $RMD_PATH )
         STEM=$(basename $RMD_PATH)
         
-        echo "RMD_PATH=\"$RMD_PATH\"" >> $GITHUB_ENV
-        echo "STEM=\"$STEM\"" >> $GITHUB_ENV
+        echo "RMD_PATH=$RMD_PATH" >> $GITHUB_ENV
+        echo "STEM=$STEM" >> $GITHUB_ENV
 
         # Create a path to the pdf by changing the extension
         PDF_PATH=${RMD_PATH/.Rmd/.pdf}
-        echo "PDF_PATH=\"$PDF_PATH\"" >> $GITHUB_ENV
+        echo "PDF_PATH=$PDF_PATH" >> $GITHUB_ENV
 
         # Folder with renv.lock and the rmd's path relative to it
         RENV_DIR="${{ inputs.renv-directory }}"
         RMD_RELATIVE_PATH="$( realpath --relative-to $RENV_DIR $RMD_PATH )"
 
-        echo "RENV_DIR=\"$RENV_DIR\"" >> $GITHUB_ENV
-        echo "RMD_RELATIVE_PATH=\"$RMD_RELATIVE_PATH\"" >> $GITHUB_ENV
+        echo "RENV_DIR=$RENV_DIR" >> $GITHUB_ENV
+        echo "RMD_RELATIVE_PATH=$RMD_RELATIVE_PATH" >> $GITHUB_ENV
 
         cat $GITHUB_ENV
 

--- a/knit-rmd-to-pdf/action.yaml
+++ b/knit-rmd-to-pdf/action.yaml
@@ -32,7 +32,7 @@ runs:
         RMD_RELATIVE_PATH=$( realpath --relative-to $RENV_DIR $RMD_PATH )
 
         echo "RENV_DIR=$RENV_DIR" >> $GITHUB_ENV
-        echo "RMD_RELATIVE_PATH=\"$RMD_RELATIVE_PATH\"" >> $GITHUB_ENV
+        echo "RMD_RELATIVE_PATH=$RMD_RELATIVE_PATH" >> $GITHUB_ENV
 
     - uses: r-lib/actions/setup-r@v2
     - uses: r-lib/actions/setup-renv@v2

--- a/knit-rmd-to-pdf/action.yaml
+++ b/knit-rmd-to-pdf/action.yaml
@@ -21,7 +21,7 @@ runs:
         RMD_NAME="$( basename $RMD_PATH .Rmd)"
         STEM="$(basename $RMD_PATH)"
         
-        echo "RMD_PATH=\"$RMD_PATH\"" >> $GITHUB_ENV
+        echo "RMD_PATH=$RMD_PATH" >> $GITHUB_ENV
         echo "STEM=\"$STEM\"" >> $GITHUB_ENV
 
         # Create a path to the pdf by changing the extension

--- a/knit-rmd-to-pdf/action.yaml
+++ b/knit-rmd-to-pdf/action.yaml
@@ -18,7 +18,7 @@ runs:
       run: |
         # Parent folder, filename, and stem of rmd_path
         RMD_PATH=${{ inputs.rmd-path }}
-        STEM="$(basename $RMD_PATH)"
+        STEM="$(basename $RMD_PATH .Rmd)"
         
         echo "RMD_PATH=$RMD_PATH" >> $GITHUB_ENV
         echo "STEM=$STEM" >> $GITHUB_ENV

--- a/knit-rmd-to-pdf/action.yaml
+++ b/knit-rmd-to-pdf/action.yaml
@@ -5,13 +5,9 @@ name: knit-rmd-to-pdf
 description: Knit an Rmarkdown file to pdf.
 
 inputs:
-  rmd-name:
+  rmd-path:
     required: true
     type: string
-  rmd-directory:
-    required: false
-    type: string
-    default: .
   renv-directory:
     required: false
     type: string
@@ -24,7 +20,7 @@ runs:
         shell: bash
         run: |
           # Parent folder, filename, and stem of rmd_path
-          RMD_PATH="${{ inputs.rmd_path }}"
+          RMD_PATH="${{ inputs.rmd-path }}"
           RMD_NAME=$( basename $RMD_PATH )
           STEM=$(basename $PDF_PATH)
           

--- a/knit-rmd-to-pdf/action.yaml
+++ b/knit-rmd-to-pdf/action.yaml
@@ -18,11 +18,10 @@ runs:
       run: |
         # Parent folder, filename, and stem of rmd_path
         RMD_PATH=${{ inputs.rmd-path }}
-        RMD_NAME="$( basename $RMD_PATH .Rmd)"
         STEM="$(basename $RMD_PATH)"
         
         echo "RMD_PATH=$RMD_PATH" >> $GITHUB_ENV
-        echo "STEM=\"$STEM\"" >> $GITHUB_ENV
+        echo "STEM=$STEM" >> $GITHUB_ENV
 
         # Create a path to the pdf by changing the extension
         PDF_PATH="${RMD_PATH/.Rmd/.pdf}"

--- a/knit-rmd-to-pdf/action.yaml
+++ b/knit-rmd-to-pdf/action.yaml
@@ -37,7 +37,8 @@ runs:
 
     - uses: r-lib/actions/setup-r@v2
     - uses: r-lib/actions/setup-renv@v2
-      working-directory: "${{ env.RENV_DIR }}"
+      with:
+        working-directory: "${{ env.RENV_DIR }}"
     
     - uses: r-lib/actions/setup-pandoc@v2
     - uses: r-lib/actions/setup-tinytex@v2

--- a/knit-rmd-to-pdf/action.yaml
+++ b/knit-rmd-to-pdf/action.yaml
@@ -50,6 +50,10 @@ runs:
       run: |
         # to make sure a new pdf is created
         rm -f "$PDF_PATH"
+
+        # debug
+        pwd
+        
         # so that renv is activated
         cd $RENV_DIR
         Rscript -e "rmarkdown::render('$RMD_RELATIVE_PATH')"

--- a/knit-rmd-to-pdf/action.yaml
+++ b/knit-rmd-to-pdf/action.yaml
@@ -35,6 +35,9 @@ runs:
         echo "RENV_DIR=\"$RENV_DIR\"" >> $GITHUB_ENV
         echo "RMD_RELATIVE_PATH=\"$RMD_RELATIVE_PATH\"" >> $GITHUB_ENV
 
+        cat $GITHUB_ENV
+        exit 1
+
     - uses: r-lib/actions/setup-r@v2
     - uses: r-lib/actions/setup-renv@v2
       with:

--- a/knit-rmd-to-pdf/action.yaml
+++ b/knit-rmd-to-pdf/action.yaml
@@ -36,7 +36,6 @@ runs:
         echo "RMD_RELATIVE_PATH=\"$RMD_RELATIVE_PATH\"" >> $GITHUB_ENV
 
         cat $GITHUB_ENV
-        exit 1
 
     - uses: r-lib/actions/setup-r@v2
     - uses: r-lib/actions/setup-renv@v2

--- a/knit-rmd-to-pdf/action.yaml
+++ b/knit-rmd-to-pdf/action.yaml
@@ -22,7 +22,7 @@ runs:
           # Parent folder, filename, and stem of rmd_path
           RMD_PATH="${{ inputs.rmd-path }}"
           RMD_NAME=$( basename $RMD_PATH )
-          STEM=$(basename $PDF_PATH)
+          STEM=$(basename $RMD_PATH)
           
           echo "RMD_PATH=\"$RMD_PATH\"" >> $GITHUB_ENV
           echo "STEM=\"$STEM\"" >> $GITHUB_ENV
@@ -40,7 +40,7 @@ runs:
           
     - uses: r-lib/actions/setup-r@v2
     - uses: r-lib/actions/setup-renv@v2
-      working-directory: "${{ env.RENV_DIR}}"
+      working-directory: "${{ env.RENV_DIR }}"
     
     - uses: r-lib/actions/setup-pandoc@v2
     - uses: r-lib/actions/setup-tinytex@v2
@@ -49,10 +49,10 @@ runs:
       shell: bash
       run: |
         # to make sure a new pdf is created
-        rm $PDF_PATH
+        rm -f "$PDF_PATH"
         # so that renv is activated
         cd $RENV_DIR
-        Rscript -e "rmarkdown::render($RMD_RELATIVE_PATH')"
+        Rscript -e "rmarkdown::render('$RMD_RELATIVE_PATH')"
     
     - uses: actions/upload-artifact@v3
       with:

--- a/knit-rmd-to-pdf/action.yaml
+++ b/knit-rmd-to-pdf/action.yaml
@@ -41,7 +41,7 @@ runs:
     - uses: r-lib/actions/setup-r@v2
     - uses: r-lib/actions/setup-renv@v2
       with:
-        working-directory: "${{ env.RENV_DIR }}"
+        working-directory: ${{ env.RENV_DIR }}
     
     - uses: r-lib/actions/setup-pandoc@v2
     - uses: r-lib/actions/setup-tinytex@v2

--- a/knit-rmd-to-pdf/action.yaml
+++ b/knit-rmd-to-pdf/action.yaml
@@ -38,7 +38,7 @@ runs:
     - uses: r-lib/actions/setup-r@v2
     - uses: r-lib/actions/setup-renv@v2
       with:
-        working-directory: ${{ inputs.rmd-path }}
+        working-directory: ${{ inputs.renv-directory }}
     
     - uses: r-lib/actions/setup-pandoc@v2
     - uses: r-lib/actions/setup-tinytex@v2

--- a/knit-rmd-to-pdf/action.yaml
+++ b/knit-rmd-to-pdf/action.yaml
@@ -1,6 +1,3 @@
-# Workflow adapted from 
-# https://github.com/r-lib/actions/tree/v2/examples#render-rmarkdown
-
 name: knit-rmd-to-pdf
 description: Knit an Rmarkdown file to pdf.
 
@@ -16,28 +13,28 @@ inputs:
 runs:
   using: "composite"
   steps:
-      - name: Manipulate path strings
-        shell: bash
-        run: |
-          # Parent folder, filename, and stem of rmd_path
-          RMD_PATH="${{ inputs.rmd-path }}"
-          RMD_NAME=$( basename $RMD_PATH )
-          STEM=$(basename $RMD_PATH)
-          
-          echo "RMD_PATH=\"$RMD_PATH\"" >> $GITHUB_ENV
-          echo "STEM=\"$STEM\"" >> $GITHUB_ENV
-  
-          # Create a path to the pdf by changing the extension
-          PDF_PATH=${RMD_PATH/.Rmd/.pdf}
-          echo "PDF_PATH=\"$PDF_PATH\"" >> $GITHUB_ENV
+    - name: Manipulate path strings
+      shell: bash
+      run: |
+        # Parent folder, filename, and stem of rmd_path
+        RMD_PATH="${{ inputs.rmd-path }}"
+        RMD_NAME=$( basename $RMD_PATH )
+        STEM=$(basename $RMD_PATH)
+        
+        echo "RMD_PATH=\"$RMD_PATH\"" >> $GITHUB_ENV
+        echo "STEM=\"$STEM\"" >> $GITHUB_ENV
 
-          # Folder with renv.lock and the rmd's path relative to it
-          RENV_DIR="${{ inputs.renv-directory }}"
-          RMD_RELATIVE_PATH="$( realpath --relative-to $RENV_DIR $RMD_PATH )"
+        # Create a path to the pdf by changing the extension
+        PDF_PATH=${RMD_PATH/.Rmd/.pdf}
+        echo "PDF_PATH=\"$PDF_PATH\"" >> $GITHUB_ENV
 
-          echo "RENV_DIR=\"$RENV_DIR\"" >> $GITHUB_ENV
-          echo "RMD_RELATIVE_PATH=\"$RMD_RELATIVE_PATH\"" >> $GITHUB_ENV
-          
+        # Folder with renv.lock and the rmd's path relative to it
+        RENV_DIR="${{ inputs.renv-directory }}"
+        RMD_RELATIVE_PATH="$( realpath --relative-to $RENV_DIR $RMD_PATH )"
+
+        echo "RENV_DIR=\"$RENV_DIR\"" >> $GITHUB_ENV
+        echo "RMD_RELATIVE_PATH=\"$RMD_RELATIVE_PATH\"" >> $GITHUB_ENV
+
     - uses: r-lib/actions/setup-r@v2
     - uses: r-lib/actions/setup-renv@v2
       working-directory: "${{ env.RENV_DIR }}"

--- a/knit-rmd-to-pdf/action.yaml
+++ b/knit-rmd-to-pdf/action.yaml
@@ -5,9 +5,13 @@ name: knit-rmd-to-pdf
 description: Knit an Rmarkdown file to pdf.
 
 inputs:
-  rmd_path:
+  rmd-name:
     required: true
     type: string
+  rmd-directory:
+    required: false
+    type: string
+    default: .
   renv-directory:
     required: false
     type: string
@@ -16,29 +20,44 @@ inputs:
 runs:
   using: "composite"
   steps:
+      - name: Manipulate path strings
+        shell: bash
+        run: |
+          # Parent folder, filename, and stem of rmd_path
+          RMD_PATH="${{ inputs.rmd_path }}"
+          RMD_NAME=$( basename $RMD_PATH )
+          STEM=$(basename $PDF_PATH)
+          
+          echo "RMD_PATH=\"$RMD_PATH\"" >> $GITHUB_ENV
+          echo "STEM=\"$STEM\"" >> $GITHUB_ENV
+  
+          # Create a path to the pdf by changing the extension
+          PDF_PATH=${RMD_PATH/.Rmd/.pdf}
+          echo "PDF_PATH=\"$PDF_PATH\"" >> $GITHUB_ENV
+
+          # Folder with renv.lock and the rmd's path relative to it
+          RENV_DIR="${{ inputs.renv-directory }}"
+          RMD_RELATIVE_PATH="$( realpath --relative-to $RENV_DIR $RMD_PATH )"
+
+          echo "RENV_DIR=\"$RENV_DIR\"" >> $GITHUB_ENV
+          echo "RMD_RELATIVE_PATH=\"$RMD_RELATIVE_PATH\"" >> $GITHUB_ENV
+          
     - uses: r-lib/actions/setup-r@v2
     - uses: r-lib/actions/setup-renv@v2
-      working-directory: ${{ inputs.renv-directory }}
+      working-directory: "${{ env.RENV_DIR}}"
     
     - uses: r-lib/actions/setup-pandoc@v2
     - uses: r-lib/actions/setup-tinytex@v2
-    
+            
     - name: Render Rmarkdown files
       shell: bash
-      run: Rscript -e "rmarkdown::render('${{ inputs.rmd_path }}')"
-    
-    - name: Manipulate path strings
-      shell: bash
       run: |
-        # Change extension in RMD_PATH to pdf
-        RMD_PATH=${{ inputs.rmd_path }}
-        PDF_PATH=${RMD_PATH/.Rmd/.pdf}
-        echo "PDF_PATH=$PDF_PATH" >> $GITHUB_ENV
-        
-        # Get the stem the filename without path (manuscript/main.pdf -> main)
-        STEM=$(basename $PDF_PATH .pdf)
-        echo "STEM=$STEM" >> $GITHUB_ENV
-        
+        # to make sure a new pdf is created
+        rm $PDF_PATH
+        # so that renv is activated
+        cd $RENV_DIR
+        Rscript -e "rmarkdown::render($RMD_RELATIVE_PATH')"
+    
     - uses: actions/upload-artifact@v3
       with:
         name: ${{ env.STEM }}

--- a/knit-rmd-to-pdf/action.yaml
+++ b/knit-rmd-to-pdf/action.yaml
@@ -18,24 +18,22 @@ runs:
       run: |
         # Parent folder, filename, and stem of rmd_path
         RMD_PATH=${{ inputs.rmd-path }}
-        RMD_NAME=$( basename $RMD_PATH )
-        STEM=$(basename $RMD_PATH)
+        RMD_NAME="$( basename $RMD_PATH .Rmd)"
+        STEM="$(basename $RMD_PATH)"
         
-        echo "RMD_PATH=$RMD_PATH" >> $GITHUB_ENV
-        echo "STEM=$STEM" >> $GITHUB_ENV
+        echo "RMD_PATH=\"$RMD_PATH\"" >> $GITHUB_ENV
+        echo "STEM=\"$STEM\"" >> $GITHUB_ENV
 
         # Create a path to the pdf by changing the extension
-        PDF_PATH=${RMD_PATH/.Rmd/.pdf}
+        PDF_PATH="${RMD_PATH/.Rmd/.pdf}"
         echo "PDF_PATH=$PDF_PATH" >> $GITHUB_ENV
 
         # Folder with renv.lock and the rmd's path relative to it
-        RENV_DIR="${{ inputs.renv-directory }}"
+        RENV_DIR=${{ inputs.renv-directory }}
         RMD_RELATIVE_PATH="$( realpath --relative-to $RENV_DIR $RMD_PATH )"
 
-        echo "RENV_DIR=$RENV_DIR" >> $GITHUB_ENV
-        echo "RMD_RELATIVE_PATH=$RMD_RELATIVE_PATH" >> $GITHUB_ENV
-
-        cat $GITHUB_ENV
+        echo "RENV_DIR=\"$RENV_DIR\"" >> $GITHUB_ENV
+        echo "RMD_RELATIVE_PATH=\"$RMD_RELATIVE_PATH\"" >> $GITHUB_ENV
 
     - uses: r-lib/actions/setup-r@v2
     - uses: r-lib/actions/setup-renv@v2

--- a/knit-rmd-to-pdf/action.yaml
+++ b/knit-rmd-to-pdf/action.yaml
@@ -1,3 +1,6 @@
+# Workflow adapted from 
+# https://github.com/r-lib/actions/tree/v2/examples#render-rmarkdown
+
 name: knit-rmd-to-pdf
 description: Knit an Rmarkdown file to pdf.
 

--- a/knit-rmd-to-pdf/action.yaml
+++ b/knit-rmd-to-pdf/action.yaml
@@ -29,7 +29,7 @@ runs:
 
         # Folder with renv.lock and the rmd's path relative to it
         RENV_DIR=${{ inputs.renv-directory }}
-        RMD_RELATIVE_PATH="$( realpath --relative-to $RENV_DIR $RMD_PATH )"
+        RMD_RELATIVE_PATH=$( realpath --relative-to $RENV_DIR $RMD_PATH )
 
         echo "RENV_DIR=$RENV_DIR" >> $GITHUB_ENV
         echo "RMD_RELATIVE_PATH=\"$RMD_RELATIVE_PATH\"" >> $GITHUB_ENV

--- a/knit-rmd-to-pdf/action.yaml
+++ b/knit-rmd-to-pdf/action.yaml
@@ -40,7 +40,7 @@ runs:
     - uses: r-lib/actions/setup-r@v2
     - uses: r-lib/actions/setup-renv@v2
       with:
-        working-directory: manuscript
+        working-directory: ${{ inputs.rmd-path }}
     
     - uses: r-lib/actions/setup-pandoc@v2
     - uses: r-lib/actions/setup-tinytex@v2

--- a/knit-rmd-to-pdf/action.yaml
+++ b/knit-rmd-to-pdf/action.yaml
@@ -40,7 +40,7 @@ runs:
     - uses: r-lib/actions/setup-r@v2
     - uses: r-lib/actions/setup-renv@v2
       with:
-        working-directory: ${{ env.RENV_DIR }}
+        working-directory: manuscript
     
     - uses: r-lib/actions/setup-pandoc@v2
     - uses: r-lib/actions/setup-tinytex@v2


### PR DESCRIPTION
For cases when renv.lock and the library aren't in the root.